### PR TITLE
Remove pry require in scraper.rb

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 require 'require_all'
 require 'scraped'
 require 'scraperwiki'


### PR DESCRIPTION
The `pry` gem is in the development group in the `Gemfile`, which means it doesn't get installed on morph.io. This was causing an error with this require.

The alternative would be to move pry out of the `development` group in the `Gemfile`, but that doesn't seem sensible since pry very much _is_ for development, and a `binding.pry` wouldn't work on Morph anyway.

Fixes #2 